### PR TITLE
Hotfix/install-hook

### DIFF
--- a/plugin-name/includes/Main.php
+++ b/plugin-name/includes/Main.php
@@ -32,6 +32,8 @@ final class Main {
 	 */
 	public static function bootstrap() {
 
+		register_activation_hook( PLUGIN_FILE, array( Install::class, 'install' ) );
+
 		add_action( 'plugins_loaded', array( __CLASS__, 'load' ) );
 
 		add_action( 'init', array( __CLASS__, 'init' ) );
@@ -71,8 +73,6 @@ final class Main {
 		if ( ! self::check_plugin_requirements() ) {
 			return;
 		}
-
-		register_activation_hook( PLUGIN_FILE, array( Install::class, 'install' ) );
 
 		if ( Utils::is_request( 'admin' ) ) {
 			Admin::hooks();


### PR DESCRIPTION
> Registering the hook inside the ‘plugins_loaded’ hook will not work. You can’t call register_activation_hook() inside a function hooked to the 'plugins_loaded' or 'init' hooks (or any other hook). These hooks are called before the plugin is loaded or activated.

[Source](https://developer.wordpress.org/reference/functions/register_activation_hook/)